### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CC := g++ -std=c++11
+CXX := g++
 DIR_HEADER := ./header
 DIR_SOURCE := ./source
-CFLAGS :=  -g -c -I ./header -O2
+CXXFLAGS := -std=c++11 -g -c -I ./header -O2
 TARGET := main
 
 
@@ -13,22 +13,22 @@ LIBOBJ = $(patsubst %.cpp,%.o,${LIBSRC})
 
 
 all : $(LIBOBJ) main.cpp
-	${CC} -o main.exe $^
+	${CXX} -o main.exe $^
 
 
 TEST-ROUTING : $(LIBOBJ) ROUTINGTEST.cpp
-	${CC} -o ROUTINGTEST.exe $^
+	${CXX} -o ROUTINGTEST.exe $^
 
 #之後在想一下怎麼自動檢查對應的.hpp , 就可以改成%.o :%.hpp , 但我現在還沒想到
-graph.o:${DIR_SOURCE}/graph.cpp ${DIR_HEADER}/graph.hpp ${DIR_HEADER}/data_structure.hpp
-	${CC} ${CFLAGS} ${DIR_SOURCE}/graph.cpp ${DIR_SOURCE}/graph.o
+${DIR_SOURCE}/graph.o:${DIR_SOURCE}/graph.cpp ${DIR_HEADER}/graph.hpp ${DIR_HEADER}/data_structure.hpp
+	${CXX} ${CXXFLAGS} ${DIR_SOURCE}/graph.cpp -o ${DIR_SOURCE}/graph.o
 
-data_structure.o:${DIR_SOURCE}/data_structure.cpp ${DIR_HEADER}/data_structure.hpp
-	${CC} ${CFLAGS} ${DIR_SOURCE}/data_structure.cpp ${DIR_SOURCE}/data_structure.o
+${DIR_SOURCE}/data_structure.o:${DIR_SOURCE}/data_structure.cpp ${DIR_HEADER}/data_structure.hpp
+	${CXX} ${CXXFLAGS} ${DIR_SOURCE}/data_structure.cpp -o ${DIR_SOURCE}/data_structure.o
 
-Routing.o:${DIR_SOURCE}/Routing.cpp ${DIR_HEADER}/data_structure.hpp ${DIR_HEADER}/graph.hpp
-	${CC} ${CFLAGS} ${DIR_SOURCE}/Routing.cpp  ${DIR_SOURCE}/Routing.o
+${DIR_SOURCE}/Routing.o:${DIR_SOURCE}/Routing.cpp ${DIR_HEADER}/data_structure.hpp ${DIR_HEADER}/graph.hpp
+	${CXX} ${CXXFLAGS} ${DIR_SOURCE}/Routing.cpp -o ${DIR_SOURCE}/Routing.o
 
-
+.PHONY: clean
 clean:
-	 rm -rf $(LIBOBJ)
+	$(RM) $(LIBOBJ)


### PR DESCRIPTION
${LIBOBJ} 應該是 ./source/Routing.o ./source/data_structure.o ./source/graph.o
所以原本的
graph.o:${DIR_SOURCE}/graph.cpp ${DIR_HEADER}/graph.hpp ${DIR_HEADER}/data_structure.hpp
應該改成
${DIR_SOURCE}/graph.o:${DIR_SOURCE}/graph.cpp ${DIR_HEADER}/graph.hpp ${DIR_HEADER}/data_structure.hpp
否則會被當作是Makefile 的 Implicit Rules, flag會沒有作用